### PR TITLE
Fix beh_lib.sv syntax error when using RV_FPGA_OPTIMIZE

### DIFF
--- a/design/lib/beh_lib.sv
+++ b/design/lib/beh_lib.sv
@@ -145,13 +145,7 @@ module rvdffe #( parameter WIDTH=1 )
 
 `ifdef RV_FPGA_OPTIMIZE
 
-`ifndef PHYSICAL   
-   begin: genblock
-`endif
      rvdffs #(WIDTH) dff ( .* );
-`ifndef PHYSICAL   
-   end
-`endif
 
 `else
    


### PR DESCRIPTION
As was reported in https://github.com/chipsalliance/Cores-SweRVolf/issues/1 , verilator reports a syntax error in beh_lib.sv when using RV_FPGA_OPTIMIZE. Older versions of Verilator parses this fine, but it seems there has been a stricter check introduced somewhere between versions 4.006 and 4.010. I also noticed that Icarus verilog doesn't handle this syntax either. This patch simplifies the expression to work in all cases