### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: cpp
+
+cache: ccache
+
+env:
+  global:
+    - VERILATOR_CACHE=$HOME/verilator_cache
+    - VERILATOR_ROOT=$PWD/verilator
+    - VERILATOR_NUM_JOBS=$((`nproc` + 1))
+    - OBJCACHE=ccache
+    - VERILATOR=$VERILATOR_ROOT/bin/verilator
+    - RV_ROOT=$PWD
+
+cache:
+  directories:
+    - $VERILATOR_CACHE
+
+before_install:
+  - git clone https://github.com/verilator/verilator.git $VERILATOR_ROOT
+# This is the first revision with the build_verilator.sh script.
+# Once a Verilator release captures this, it would be best to check out
+# a release tag instead.
+  - git -C $VERILATOR_ROOT checkout 46ab907f6afdcacbf848ea090dce66f1334de663
+
+before_script:
+  - $VERILATOR_ROOT/ci/build_verilator.sh
+
+stages:
+  - build
+  - test
+
+jobs:
+  include:
+    - stage: build
+      name: Build Verilator
+      script: echo "Done building Verilator"
+    - stage: test
+      name: Run Tests
+      script:
+        - configs/swerv.config -snapshot=mybuild
+        - make -j 4 -f tools/Makefile verilator snapshot=mybuild
+        - make -f tools/Makefile verilator-run snapshot=mybuild |& tee sim.log
+        - grep -q "Hello World from SweRV" sim.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - VERILATOR_ROOT=$PWD/verilator
     - VERILATOR_NUM_JOBS=$((`nproc` + 1))
     - OBJCACHE=ccache
+    - PATH=$PATH:$VERILATOR_ROOT/bin
     - VERILATOR=$VERILATOR_ROOT/bin/verilator
     - RV_ROOT=$PWD
 


### PR DESCRIPTION
Adding Travis CI support since this is one of the verilator_ext_tests submodules:
https://github.com/verilator/verilator_ext_tests

This will give you free testing (since this is open source) on the Travis platform. It also tests any incoming PRs automatically. You can see how this will work in Travis on my branch at the moment:
https://travis-ci.com/toddstrader/Cores-SweRV/jobs/246471515

There are some notes in the Verilator documentation about how to set up a Travis CI account and link it to your GitHub account. You'd need to do that for the ZipCPU account after merging this.
https://github.com/verilator/verilator/blob/master/docs/internals.adoc#continuous-integration

Right now I'm just cloning the Verilator repo in Travis. If you'd prefer I could change that to be a Git submodule. Either way will work.

Also, if you want a nifty Travis badge in your README, I can add that too. But I need at least one Travis build on master to bootstrap that. See here for an example:
https://github.com/verilator/verilator/blob/master/README.pod