### PR TITLE
Add initial FuseSoC support

### DIFF
--- a/configs/swerv_config_gen.py
+++ b/configs/swerv_config_gen.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+from fusesoc.capi2.generator import Generator
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+if sys.version[0] == '2':
+    devnull = open(os.devnull, 'w')
+else:
+    from subprocess import DEVNULL as devnull
+
+class SwervConfigGenerator(Generator):
+    def run(self):
+        script_root = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+        files = [
+            {"configs/snapshots/default/common_defines.vh" : {
+                "copyto"    : "config/common_defines.vh",
+                "file_type" : "systemVerilogSource"}},
+            {"configs/snapshots/default/pic_ctrl_verilator_unroll.sv" : {
+                "copyto" : "config/pic_ctrl_verilator_unroll.sv",
+                "is_include_file" : True,
+                "file_type" : "systemVerilogSource"}},
+            {"configs/snapshots/default/pic_map_auto.h" : {
+                "copyto" : "config/pic_map_auto.h",
+                "is_include_file" : True,
+                "file_type" : "systemVerilogSource"}}]
+
+        tmp_dir = os.path.join(tempfile.mkdtemp(), 'core')
+        shutil.copytree(script_root, tmp_dir)
+
+        cwd = tmp_dir
+
+        env = os.environ.copy()
+        env['RV_ROOT'] = tmp_dir
+        args = ['configs/swerv.config'] + self.config.get('args', [])
+        rc = subprocess.call(args, cwd=cwd, env=env, stdout=devnull)
+        if rc:
+            exit(1)
+
+        filenames = []
+        for f in files:
+            for k in f:
+                filenames.append(k)
+
+        for f in filenames:
+            d = os.path.dirname(f)
+            if d and not os.path.exists(d):
+                os.makedirs(d)
+            shutil.copy2(os.path.join(cwd, f),f)
+
+        self.add_files(files)
+
+g = SwervConfigGenerator()
+g.run()
+g.write()

--- a/swerv.core
+++ b/swerv.core
@@ -1,0 +1,143 @@
+CAPI=2:
+
+name : chipsalliance.org:cores:SweRV_EH1:1.5
+
+filesets:
+  rtl:
+    files:
+      - design/include/swerv_types.sv
+      - design/lib/beh_lib.sv
+      - design/mem.sv
+      - design/pic_ctrl.sv
+      - design/dma_ctrl.sv
+      - design/ifu/ifu_aln_ctl.sv
+      - design/ifu/ifu_compress_ctl.sv
+      - design/ifu/ifu_ifc_ctl.sv
+      - design/ifu/ifu_bp_ctl.sv
+      - design/ifu/ifu_ic_mem.sv
+      - design/ifu/ifu_mem_ctl.sv
+      - design/ifu/ifu_iccm_mem.sv
+      - design/ifu/ifu.sv
+      - design/dec/dec_decode_ctl.sv
+      - design/dec/dec_gpr_ctl.sv
+      - design/dec/dec_ib_ctl.sv
+      - design/dec/dec_tlu_ctl.sv
+      - design/dec/dec_trigger.sv
+      - design/dec/dec.sv
+      - design/exu/exu_alu_ctl.sv
+      - design/exu/exu_mul_ctl.sv
+      - design/exu/exu_div_ctl.sv
+      - design/exu/exu.sv
+      - design/lsu/lsu.sv
+      - design/lsu/lsu_bus_buffer.sv
+      - design/lsu/lsu_clkdomain.sv
+      - design/lsu/lsu_addrcheck.sv
+      - design/lsu/lsu_lsc_ctl.sv
+      - design/lsu/lsu_stbuf.sv
+      - design/lsu/lsu_bus_intf.sv
+      - design/lsu/lsu_ecc.sv
+      - design/lsu/lsu_dccm_mem.sv
+      - design/lsu/lsu_dccm_ctl.sv
+      - design/lsu/lsu_trigger.sv
+      - design/dbg/dbg.sv
+      - design/dmi/dmi_wrapper.v
+      - design/dmi/dmi_jtag_to_core_sync.v
+      - design/dmi/rvjtag_tap.sv
+      - design/lib/mem_lib.sv
+      - design/lib/ahb_to_axi4.sv
+      - design/lib/axi4_to_ahb.sv
+      - design/swerv.sv
+      - design/swerv_wrapper.sv
+    file_type : systemVerilogSource
+
+  includes:
+    files:
+      - design/include/build.h : {is_include_file : true}
+      - design/include/global.h : {is_include_file : true}
+    file_type : systemVerilogSource
+
+  mem_init:
+    files:
+      - testbench/hex/data.hex : {copyto : data.hex}
+      - testbench/hex/program.hex : {copyto : program.hex}
+    file_type : user
+
+  tb:
+    files: [testbench/ahb_sif.sv, testbench/tb_top.sv]
+    file_type : systemVerilogSource
+
+  verilator_tb:
+    files : [testbench/test_tb_top.cpp : {file_type : cppSource}]
+
+  vivado_tcl: {files: [tools/vivado.tcl : {file_type : tclSource}]}
+
+targets:
+  default:
+    filesets :
+      - includes
+      - rtl
+      - "tool_vivado ? (vivado_tcl)"
+  lint:
+    default_tool: verilator
+    filesets : [includes, rtl]
+    generate : [swerv_default_config]
+    tools:
+      verilator :
+        mode : lint-only
+    toplevel : swerv_wrapper
+
+  sim:
+    default_tool : verilator
+    filesets :
+      - includes
+      - rtl
+      - mem_init
+      - tb
+      - "tool_verilator? (verilator_tb)"
+
+    generate : [swerv_ahb_config]
+    tools:
+      modelsim:
+        vlog_options :
+          - -mfcu
+          - -cuautoname=du
+          - config/common_defines.vh
+      verilator:
+        verilator_options : [--trace, -Wno-fatal]
+    toplevel : tb_top
+
+  synth:
+    default_tool : vivado
+    filesets : [includes, rtl, vivado_tcl]
+    generate : [swerv_fpga_config]
+    tools:
+      vivado:
+        part : xc7a100tcsg324-1
+        pnr  : none
+    toplevel : swerv_wrapper
+
+generate:
+  swerv_ahb_config:
+    generator: swerv_config
+    position : first
+    parameters:
+      args : ['-ahb_lite', -unset=assert_on]
+
+  swerv_default_config:
+    generator: swerv_config
+    position : first
+    parameters:
+      args : [-unset=assert_on]
+
+  swerv_fpga_config:
+    generator: swerv_config
+    position : first
+    parameters:
+      args : [-unset=assert_on, -set=fpga_optimize=1]
+
+generators:
+  swerv_config:
+    interpreter: python
+    command: configs/swerv_config_gen.py
+    description : Create a SweRV configuration. Note! Only supports the default config
+

--- a/tools/vivado.tcl
+++ b/tools/vivado.tcl
@@ -1,0 +1,1 @@
+set_property is_global_include true [get_files config/common_defines.vh]


### PR DESCRIPTION
This adds support for using SweRV with FuseSoC. For SweRV itself, it allows linting with verilator running simulations with the provided testbench using most available simulators and doing synthesis for resource usage analysis with Vivado. It also allows SweRV to be integrated into FuseSoC-built SoCs, such as [SweRVolf](https://github.com/chipsalliance/Cores-SweRVolf)

**Quickstart**

1. Install [FuseSoC](https://github.com/olofk/fusesoc) and Verilator
2. Create an empty workspace directory. All subsequent commands are run from this directory
3. Add SweRV as FuseSoC library `fusesoc library add swerv https://github.com/chipsalliance/Cores-SweRV`
4. Run linting with Verilator `fusesoc run --target=lint chipsalliance.org:cores:SweRV_EH1`
5. Run testbench with default simulator (Verilator) `fusesoc run --target=sim chipsalliance.org:cores:SweRV_EH1`
6. Run testbench with another supported simulator (e.g. ModelSim) `fusesoc run --target=sim --tool=modelsim chipsalliance.org:cores:SweRV_EH1`
7. Run synthesis with Vivado `fusesoc run --target=synth chipsalliance.org:cores:SweRV_EH1`

* configs/swerv_config_gen.py is a wrapper around `configs/swerv.config` to dynamically create a SweRV configuration by setting parameters in the FuseSoC .core file
* swerv.core is the FuseSoC core description file
* tools/vivado.tcl marks `common_defines.vh` as a global include file when using Vivado