### PR TITLE
Build Verilator without --trace support unless debug given.

### DIFF
--- a/testbench/test_tb_top.cpp
+++ b/testbench/test_tb_top.cpp
@@ -47,23 +47,33 @@ int main(int argc, char** argv) {
   Vtb_top* tb = new Vtb_top;
 
   // init trace dump
-  Verilated::traceEverOn(true);
-  VerilatedVcdC* tfp = new VerilatedVcdC;
-  tb->trace (tfp, 24);
-  if (dumpWaves)
+  VerilatedVcdC* tfp = NULL;
+  if (dumpWaves) {
+#if VM_TRACE
+    tfp = new VerilatedVcdC;
+    Verilated::traceEverOn(true);
+    tb->trace (tfp, 24);
     tfp->open ("sim.vcd");
+#else
+    std::cout << "\nVerilatorTB: +dumpon but model not compiled with --trace" << std::endl;
+#endif
+  }
 
   // Simulate
   while(!Verilated::gotFinish()){
+#if VM_TRACE
       if (dumpWaves)
         tfp->dump (main_time);
+#endif
       main_time += 5;
       tb->core_clk = !tb->core_clk;
       tb->eval();
   }
 
+#if VM_TRACE
   if (dumpWaves)
     tfp->close();
+#endif
 
   std::cout << "\nVerilatorTB: End of sim" << std::endl;
   exit(EXIT_SUCCESS);

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -46,6 +46,7 @@ ifdef debug
  IRUN_DEBUG = -access +rc
  IRUN_DEBUG_RUN = -input ${RV_ROOT}/testbench/input.tcl
  VCS_DEBUG = -debug_access
+ VERILATOR_DEBUG = --trace
  RIVIERA_DEBUG = +access +r
 endif
 
@@ -87,7 +88,8 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h test_tb_top.cpp
                 -I${RV_ROOT}/testbench \
 		-f ${RV_ROOT}/testbench/flist \
                 ${TBFILES} \
-                --top-module tb_top -exe test_tb_top.cpp --trace --autoflush
+                --top-module tb_top -exe test_tb_top.cpp --autoflush \
+		$(VERILATOR_DEBUG)
 	cp ${RV_ROOT}/testbench/test_tb_top.cpp obj_dir/
 	$(MAKE) -C obj_dir/ -f Vtb_top.mk $(VERILATOR_MAKE_FLAGS)
 	touch verilator-build
@@ -130,7 +132,7 @@ irun: program.hex irun-build
 
 vcs: program.hex vcs-build
 	./simv $(DEBUG_PLUS) +vcs+lic+wait -l vcs.log
-        
+
 vlog: program.hex ${TBFILES} ${BUILD_DIR}/defines.h
 	$(VLOG) -l vlog.log -sv -mfcu +incdir+${BUILD_DIR}+${RV_ROOT}/design/include+${RV_ROOT}/design/lib\
         $(defines) -f ${RV_ROOT}/testbench/flist ${TBFILES} -R ${DEBUG_PLUS}
@@ -173,4 +175,4 @@ help:
 	@echo Make sure the environment variable RV_ROOT is set.
 	@echo Possible targets: verilator vcs irun vlog riviera help clean all verilator-build irun-build vcs-build riviera-build program.hex
 
-.PHONY: help clean verilator vcs irun vlog riviera 
+.PHONY: help clean verilator vcs irun vlog riviera


### PR DESCRIPTION
This pull request fixes test_tb_top.cpp to be able to compile when --trace is not used.

This also turns off --trace in the Makefile unless debug is set, like the other simulators.  If you don't want to change this please consider the other patches, I can update if needed.

This also fixes a whitespace error in the last commit.

Please also consider applying a similar change to EH2 as needed, thanks.
