### PR TITLE
fix for assignment to enum variable from expression of different type

### DIFF
--- a/design/ifu/ifu_ifc_ctl.sv
+++ b/design/ifu/ifu_ifc_ctl.sv
@@ -185,11 +185,11 @@ module ifu_ifc_ctl
 //11 0-10- 01
 //11 0-00- 11
 
-   assign next_state[1] = (~state[1] & state[0] & ~reset_delayed & miss_f2 & ~goto_idle) |
-                          (state[1] & ~reset_delayed & ~mb_empty_mod & ~goto_idle);
+   assign next_state[1] = state_t'((~state[1] & state[0] & ~reset_delayed & miss_f2 & ~goto_idle) |
+                          (state[1] & ~reset_delayed & ~mb_empty_mod & ~goto_idle));
 
-   assign next_state[0] = (~goto_idle & leave_idle) | (state[0] & ~goto_idle) |
-                          (reset_delayed);
+   assign next_state[0] = state_t'((~goto_idle & leave_idle) | (state[0] & ~goto_idle) |
+                          (reset_delayed));
 
    assign flush_fb = exu_flush_final;
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -113,7 +113,6 @@ irun-build: ${TBFILES} ${BUILD_DIR}/defines.h
 riviera-build: ${TBFILES} ${BUILD_DIR}/defines.h
 	vlib work
 	vlog -work work \
-		-err VCP2694 W1 \
 		+incdir+${RV_ROOT}/design/lib \
 		+incdir+${RV_ROOT}/design/include \
 		+incdir+${BUILD_DIR} +libext+.v $(defines) \


### PR DESCRIPTION
Hey!
In this pull request I fixed assignment to enum from different type. Enum should be assignment only by enum type. LRM1800-2017 6.19.4: `A cast shall be required for an expression
that is assigned to an enum variable where the type of the expression is not equivalent to the enumeration
type of the variable.`