### PR TITLE
update swerv.core for Riviera-PRO

### DIFF
--- a/swerv.core
+++ b/swerv.core
@@ -102,6 +102,11 @@ targets:
           - -mfcu
           - -cuautoname=du
           - config/common_defines.vh
+      rivierapro:
+        vlog_options :
+          - config/common_defines.vh
+          - "-err VCP2694 W1"
+        compilation_mode : common
       verilator:
         verilator_options : [--trace, -Wno-fatal]
     toplevel : tb_top


### PR DESCRIPTION
Hey!
In this pull request I added support for Riviera-PRO for FuseSoC.
After merging pull request #49 this line:
`- "-err VCP2694 W1"`
should be remove