### PR TITLE
Always output 0 as the first bit of a DR bypass scan, per the 1149.1 …

### DIFF
--- a/design/dmi/rvjtag_tap.sv
+++ b/design/dmi/rvjtag_tap.sv
@@ -177,6 +177,7 @@ always_comb begin
                     dr_en[0]:   nsr = {{USER_DR_LENGTH-15{1'b0}}, idle, dmi_stat, abits, version};
                     dr_en[1]:   nsr = {{AWIDTH{1'b0}}, rd_data, rd_status};
                     devid_sel:  nsr = {{USER_DR_LENGTH-32{1'b0}}, jtag_id, 1'b1};
+                    default:    nsr = '0; // bypass
                     endcase
                 end
     shift_ir:   nsr = {{USER_DR_LENGTH-5{1'b0}},tdi, sr[4:1]};


### PR DESCRIPTION
…spec.