### PR TITLE
Only load Vivado TCL files when using Vivado

### DIFF
--- a/swerv.core
+++ b/swerv.core
@@ -113,7 +113,7 @@ targets:
 
   synth:
     default_tool : vivado
-    filesets : [includes, rtl, vivado_tcl]
+    filesets : [includes, rtl, "tool_vivado ? (vivado_tcl)"]
     generate : [swerv_fpga_config]
     tools:
       vivado:


### PR DESCRIPTION
This prevents the vivado-specific TCL file to be loaded when using the synth target with other synthesis tools than vivado