### PR TITLE
Remove unused scan_mode input from dmi_wrapper

### DIFF
--- a/design/dmi/dmi_wrapper.v
+++ b/design/dmi/dmi_wrapper.v
@@ -22,7 +22,6 @@
 //-------------------------------------------------------------------------------------
 
 module dmi_wrapper(
-  input              scan_mode,           // scan mode
 
   // JTAG signals
   input              trst_n,              // JTAG reset

--- a/design/swerv_wrapper.sv
+++ b/design/swerv_wrapper.sv
@@ -414,7 +414,6 @@ module swerv_wrapper
 
   // Instantiate the JTAG/DMI
    dmi_wrapper  dmi_wrapper (
-           .scan_mode(scan_mode),           // scan mode
 
            // JTAG signals
            .trst_n(jtag_trst_n),           // JTAG reset


### PR DESCRIPTION
This causes the dmi wrapper from SweRV EH1 and SweRV EL2 to have
the same interface which makes it easier to use the two CPU cores
interchangeably in a design.