### PR TITLE
Declare variables before using them

### DIFF
--- a/design/dec/dec.sv
+++ b/design/dec/dec.sv
@@ -512,13 +512,6 @@ module dec
 
    assign dec_dbg_rddata[31:0] = dec_i0_wdata_wb[31:0];
 
-   dec_ib_ctl instbuff (.*
-                        );
-
-   dec_decode_ctl decode (.*);
-
-   dec_tlu_ctl tlu (.*);
-
    // Temp hookups
    assign wen_bank_id = '0;
    assign wr_bank_id  = '0;
@@ -577,6 +570,12 @@ module dec
    assign trace_rv_trace_pkt.trace_rv_i_interrupt_ip = {dec_tlu_int_valid_wb1,2'b0};
    assign trace_rv_trace_pkt.trace_rv_i_tval_ip =    dec_tlu_mtval_wb1[31:0];        // replicate across ports
 
+   dec_ib_ctl instbuff (.*
+                        );
+
+   dec_decode_ctl decode (.*);
+
+   dec_tlu_ctl tlu (.*);
 
 
 // end trace

--- a/design/dec/dec_tlu_ctl.sv
+++ b/design/dec/dec_tlu_ctl.sv
@@ -409,6 +409,10 @@ module dec_tlu_ctl
    logic csr_wr_clk;
    rvoclkhdr csrwr_wb_cgc ( .en(dec_csr_wen_wb_mod | clk_override), .l1clk(csr_wr_clk), .* );
    logic lsu_e3_e4_clk, lsu_e4_e5_clk;
+
+   // LSU exceptions (LSU responsible for prioritizing simultaneous cases)
+   lsu_error_pkt_t lsu_error_pkt_dc4;
+
    rvoclkhdr lsu_e3_e4_cgc ( .en(lsu_error_pkt_dc3.exc_valid | lsu_error_pkt_dc4.exc_valid | lsu_error_pkt_dc3.single_ecc_error | lsu_error_pkt_dc4.single_ecc_error | clk_override), .l1clk(lsu_e3_e4_clk), .* );
    rvoclkhdr lsu_e4_e5_cgc ( .en(lsu_error_pkt_dc4.exc_valid | lsu_exc_valid_wb | clk_override), .l1clk(lsu_e4_e5_clk), .* );
 
@@ -753,9 +757,6 @@ module dec_tlu_ctl
 
    //--------------------------------------------------------------------------------
    //--------------------------------------------------------------------------------
-
-   // LSU exceptions (LSU responsible for prioritizing simultaneous cases)
-   lsu_error_pkt_t lsu_error_pkt_dc4;
 
    rvdff #( $bits(lsu_error_pkt_t)+1 ) lsu_error_dc4ff (.*, .clk(lsu_e3_e4_clk), .din({lsu_error_pkt_dc3, lsu_load_ecc_stbuf_full_dc3}),  .dout({lsu_error_pkt_dc4, lsu_load_ecc_stbuf_full_dc4}));
 

--- a/design/ifu/ifu.sv
+++ b/design/ifu/ifu.sv
@@ -258,10 +258,6 @@ module ifu
 
    logic ic_hit_f2;
 
-   // fetch control
-   ifu_ifc_ctl ifc (.*
-                    );
-
 
 `ifdef RV_BTB_48
    logic [7:0][1:0] ifu_bp_way_f2; // way indication; right justified
@@ -278,10 +274,6 @@ module ifu
    logic [7:0]  ifu_bp_pc4_f2; // pc4 indication; right justified
    logic [7:0]  ifu_bp_valid_f2; // branch valid, right justified
    logic [`RV_BHT_GHR_RANGE] ifu_bp_fghr_f2;
-
-   // branch predictor
-   ifu_bp_ctl bp (.*);
-
 
    logic [7:0]   ic_fetch_val_f2;
    logic [127:0] ic_data_f2;
@@ -302,9 +294,16 @@ module ifu
    assign ifu_fetch_val[7:0] = ic_fetch_val_f2[7:0];
    assign ifu_fetch_pc[31:1] = ifc_fetch_addr_f2[31:1];
 
+   // fetch control
+   ifu_ifc_ctl ifc (.*
+                    );
+
    // aligner
    ifu_aln_ctl aln (.*
                     );
+
+   // branch predictor
+   ifu_bp_ctl bp (.*);
 
    // icache
    ifu_mem_ctl mem_ctl

--- a/design/swerv.sv
+++ b/design/swerv.sv
@@ -989,14 +989,6 @@ module swerv
        .*
    );
 
-
-
-   dec dec (
-            .dbg_cmd_wrdata(dbg_cmd_wrdata[1:0]),
-            .rst_l(core_rst_l),
-            .*
-            );
-
    exu exu (
       .clk_override(dec_tlu_exu_clk_override),
       .rst_l(core_rst_l),
@@ -1016,6 +1008,12 @@ module swerv
    logic        mhwakeup;
 
    logic        dec_tlu_claim_ack_wb;
+
+   dec dec (
+            .dbg_cmd_wrdata(dbg_cmd_wrdata[1:0]),
+            .rst_l(core_rst_l),
+            .*
+            );
 
    pic_ctrl  pic_ctrl_inst (
                   .clk_override(dec_tlu_pic_clk_override),


### PR DESCRIPTION
`lsu_error_pkt_dc4` (and other variables) are referenced before declaration. This seems to be acceptable for some EDA tools, but not for all of them.

Ref: https://github.com/SymbiFlow/sv-tests/issues/1348