### PR TITLE
Fix  FuseSoC config generator

### DIFF
--- a/configs/swerv_config_gen.py
+++ b/configs/swerv_config_gen.py
@@ -8,14 +8,14 @@ import tempfile
 class SwervConfigGenerator(Generator):
     def run(self):
         files = [
-            {"configs/snapshots/default/common_defines.vh" : {
+            {"snapshots/default/common_defines.vh" : {
                 "copyto"    : "config/common_defines.vh",
                 "file_type" : "systemVerilogSource"}},
-            {"configs/snapshots/default/pic_ctrl_verilator_unroll.sv" : {
+            {"snapshots/default/pic_ctrl_verilator_unroll.sv" : {
                 "copyto" : "config/pic_ctrl_verilator_unroll.sv",
                 "is_include_file" : True,
                 "file_type" : "systemVerilogSource"}},
-            {"configs/snapshots/default/pic_map_auto.h" : {
+            {"snapshots/default/pic_map_auto.h" : {
                 "copyto" : "config/pic_map_auto.h",
                 "is_include_file" : True,
                 "file_type" : "systemVerilogSource"}}]


### PR DESCRIPTION
After the following change:
https://github.com/chipsalliance/Cores-SweRV/commit/ec254f5#diff-7682db868261ad0b18c9d5ca090189ad3eac89bbbcbc44530c9b2a40ee71a6eaL37
the FuseSoC tool started failing due to a missing directory
and this commit fixes it.