### PR TITLE
Remove not existing file from vivado.tcl

### DIFF
--- a/tools/vivado.tcl
+++ b/tools/vivado.tcl
@@ -1,2 +1,1 @@
 set_property is_global_include true [get_files config/common_defines.vh]
-set_property IS_GLOBAL_INCLUDE 1 [get_files include/def.sv]


### PR DESCRIPTION
This PR removes ``include/def.sv`` file (that was added in: https://github.com/chipsalliance/Cores-SweRV/commit/ec254f54915fbd38d1878fca9247bec12db2fcaf#diff-c4271083e06e1a6b127a43638fca5510e545b76a14df52fd53cead42cf73df67R2), but it doesn't exist in the repository. 

This fixes ``vivado`` target using ``fusesoc``.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>